### PR TITLE
Make the module compatible with kernel 6.12

### DIFF
--- a/driver/headset.c
+++ b/driver/headset.c
@@ -5,6 +5,7 @@
 
 #include <linux/module.h>
 #include <linux/hrtimer.h>
+#include <linux/vmalloc.h>
 #include <sound/core.h>
 #include <sound/initval.h>
 #include <sound/pcm.h>
@@ -90,13 +91,34 @@ static int gip_headset_pcm_close(struct snd_pcm_substream *sub)
 static int gip_headset_pcm_hw_params(struct snd_pcm_substream *sub,
 				     struct snd_pcm_hw_params *params)
 {
-	return snd_pcm_lib_alloc_vmalloc_buffer(sub,
-						params_buffer_bytes(params));
+	struct snd_pcm_runtime *runtime = sub->runtime;
+	size_t size = params_buffer_bytes(params);
+
+	if (runtime->dma_area) {
+		if (runtime->dma_bytes >= size)
+			return 0; /* already large enough */
+		vfree(runtime->dma_area);
+	}
+	runtime->dma_area = vzalloc(size);
+	if (!runtime->dma_area)
+		return -ENOMEM;
+	runtime->dma_bytes = size;
+	return 1;
+}
+
+static struct page *dw_hdmi_get_page(struct snd_pcm_substream *sub,
+				     unsigned long offset)
+{
+	return vmalloc_to_page(sub->runtime->dma_area + offset);
 }
 
 static int gip_headset_pcm_hw_free(struct snd_pcm_substream *sub)
 {
-	return snd_pcm_lib_free_vmalloc_buffer(sub);
+	struct snd_pcm_runtime *runtime = sub->runtime;
+
+	vfree(runtime->dma_area);
+	runtime->dma_area = NULL;
+	return 0;
 }
 
 static int gip_headset_pcm_prepare(struct snd_pcm_substream *sub)
@@ -157,7 +179,7 @@ static const struct snd_pcm_ops gip_headset_pcm_ops = {
 	.prepare = gip_headset_pcm_prepare,
 	.trigger = gip_headset_pcm_trigger,
 	.pointer = gip_headset_pcm_pointer,
-	.page = snd_pcm_lib_get_vmalloc_page,
+	.page = dw_hdmi_get_page,
 };
 
 static bool gip_headset_advance_pointer(struct gip_headset_stream *stream,


### PR DESCRIPTION
Starting from v6.12 helper functions snd_pcm_lib_alloc_vmalloc_buffer and snd_pcm_lib_free_vmalloc_buffer as well as snd_pcm_lib_get_vmalloc_page have been removed: stop using those functions in this module.